### PR TITLE
Initial package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: nodejs
+sudo: required
+dist: trusty
+
+node_js:
+- '6'
+- '4'
+- '0.12'
+- '0.10'
+
+env:
+- PROTAGONIST=true
+- PROTAGONIST=false
+
+before_install:
+- if ! "$PROTAGONIST"; then sudo apt-get purge build-essential && sudo apt-get autoremove; fi
+
+install:
+- npm install
+
+before_script:
+- if ! "$PROTAGONIST" && [ -d "node_modules/protagonist" ]; then echo "Protagonist was successfully installed (should not have been)." && exit 1; fi
+
+script:
+- npm test
+
+deploy:
+  provider: npm
+  email: sre@apiary.io
+  api_key:
+    secure: Kj+S5GtMez3gOvzJ7KtaAkEnAPi1/Ux33ImZZyZXs4M8s8yDrMsFmuWEp4DqwPFyYs0I2y5mcTpHVHPoDo7ECfHpI9URrQEtuxC3Pn1jTv/xQD21cJ5QVCa0L0wfuQMSoSRVneTFvnDwNRFUHeLFFPeiOaXtcNK0aHp/YMt87RFYfyC/yXD75XpBDj4BIMSOQouOOnimLQNSmxgnZ3zcLPc4pr5w4JtPfTnyTBvk3yc2/l5IN/m7KHGDbiwAAO1eLS6MzqwYD9Bchmh3Pnn0QZNpLjWC2i8H8FUw9TsUdzDuMjkXOrwvpyGglpf9EuffIpDXRgQVWuwzwh3/wtkMcUGUGEuBYR/tPbh01wKFXHeZeuh0qcrvMynpOKCz1tXxSUtBBKPZw8YAuV51iDVpnaBSvSV/4ZPRRJo6O8vwhk1mSPBV9euv21rUfyFLOVNWrG0niQCEzr1gHHY8EaI9NtULE1EmQTNOoujYj5jOgCgWJSthR6sygVnbGX+xqmGSCH7+yCZn7P1aqubdeXufsyAaU7qTaY1QeGWlIbR7xBQvQfyIlTUGp4Mv1tEKOMdYjpZH5KEwt64/J0bxKHn3Iu6ZZ7V1jBM3cPA3b0Cx3/wsytvYSMaxcRxenEvSYe/JtfPqGccZsD/DFzTf9IpLI2wxoavRHiuBQSfYCwAYYiY=
+  on:
+    tags: true
+    repo: apiaryio/drafter-npm

--- a/README.md
+++ b/README.md
@@ -1,1 +1,81 @@
-# drafter-npm
+![logo](https://raw.github.com/apiaryio/api-blueprint/master/assets/logo_apiblueprint.png)
+
+# Drafter NPM Package [![Build Status](https://travis-ci.org/apiaryio/drafter-npm.svg?branch=master)](https://travis-ci.org/apiaryio/drafter-npm)
+
+The Drafter NPM package is an API Blueprint parser for Node. This package is a
+wrapper around the underlying C++ parser
+[Drafter](https://github.com/apiaryio/drafter). Drafter NPM optionally depends
+on the C++ binding to Drafter
+[Protagonist](https://github.com/apiaryio/protagonist). If for any reason
+Protagonist is not installable, this package will fallback to using the slower,
+pure JavaScript version of Drafter,
+[drafter.js](https://github.com/apiaryio/drafter.js)
+
+## Installation
+
+drafter can be installed from NPM. If you're using Drafter from a web browser.
+Check out [drafter.js](https://github.com/apiaryio/drafter.js).
+
+```shell
+$ npm install drafter
+```
+
+## Usage
+
+```js
+var drafter = require('drafter');
+```
+
+Once you've included drafter, you can parse an API Blueprint asynchronously:
+
+```js
+var options = {
+  generateSourcemap: true,
+}
+
+drafter.parse('# API Blueprint...', options, function(err, result) {
+  if (err) {
+    console.log(err);
+  } else {
+    console.log(result);
+  }
+});
+```
+
+Alternatively, you can use Drafter synchronously:
+
+```js
+try {
+  var result = drafter.parse('# API Blueprint...', options);
+  console.log(result);
+} catch (err) {
+  console.log(err);
+}
+```
+
+### Parsing Options
+
+Options can be passed to the parser as an optional second argument to both the
+asynchronous and synchronous interfaces:
+
+```js
+var options = {
+  generateSourceMap: true
+}
+
+drafter.parse('# My API', options, callback);
+```
+
+The available options are:
+
+Name                   | Description
+---------------------- | ----------------------------------------------------------
+`requireBlueprintName` | Require parsed blueprints have a title (default: false)
+`generateSourceMap`    | Enable sourcemap generation (default: false)
+`type`                 | Set the output structure type as either `ast` or `refract` (default: `refract`)
+
+**NOTE**: *The `ast` option is deprecated in favour of `refract`.*
+
+## License
+
+MIT License. See the [LICENSE](LICENSE) file.

--- a/lib/drafter.js
+++ b/lib/drafter.js
@@ -1,0 +1,15 @@
+try {
+  var protagonist = require('protagonist')
+
+  module.exports = {
+    parse: protagonist.parse,
+    parseSync: protagonist.parseSync,
+  };
+} catch (error) {
+  var drafterjs = require('drafter.js')
+
+  module.exports = {
+    parse: drafterjs.parse,
+    parseSync: drafterjs.parseSync,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "drafter",
+  "version": "1.0.0",
+  "description": "Node API Blueprint Parser",
+  "main": "lib/drafter.js",
+  "engines": {
+    "node": ">= 0.12"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/apiaryio/drafter-npm"
+  },
+  "author": "Apiary",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/apiaryio/drafter-npm/issues"
+  },
+  "homepage": "https://github.com/apiaryio/drafter-npm",
+  "scripts": {
+    "test": "mocha"
+  },
+  "dependencies": {
+    "drafter.js": "^2.4.3"
+  },
+  "optionalDependencies": {
+    "protagonist": "^1.4.1"
+  },
+  "devDependencies": {
+    "mocha": "~1.17.1",
+    "chai": "~1.9.0"
+  }
+}

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -1,0 +1,34 @@
+var expect = require('chai').expect;
+var drafter = require('../lib/drafter.js');
+
+describe('Parsing an API Blueprint', function() {
+  var blueprint = '# API Blueprint\n';
+  var parseResult = {
+    element: 'parseResult',
+    content: [
+      {
+        element: 'category',
+        meta: {
+          classes: ['api'],
+          title: 'API Blueprint',
+        },
+        content: [],
+      }
+    ]
+  }
+
+  it('should parse an API Blueprint asyncronously', function(done) {
+    drafter.parse(blueprint, {}, function(error, result) {
+      expect(error).to.be.null;
+      expect(result).to.deep.equal(parseResult);
+      done();
+    });
+  });
+
+  it('should parse an API Blueprint syncronously', function() {
+    var blueprint = '# API Blueprint';
+
+    var result = drafter.parseSync(blueprint, {});
+    expect(result).to.deep.equal(parseResult);
+  });
+});


### PR DESCRIPTION
This pull request introduces the initial version of Drafter NPM (version 1.0.0) which provides an NPM package for API Blueprint parsing. This package will optionally depend on Protagonist and fallback to Drafter.js when Protagonist isn't installable.

To be able to test this during CI, I've added a step to Travis CI to uninstall the ubuntu build-essentials package which removes the compiler to make the optional dependency of Protagonist fail. There is an additional assertion that the node_modules directory doesn't contain protagonist just incase something in Travis CI changes in the future and the Protagonist package is installed successfully.
