### PR TITLE
Add support for validating an API Blueprint

### DIFF
--- a/lib/drafter.js
+++ b/lib/drafter.js
@@ -4,6 +4,9 @@ try {
   module.exports = {
     parse: protagonist.parse,
     parseSync: protagonist.parseSync,
+
+    validate: protagonist.validate,
+    validateSync: protagonist.validateSync,
   };
 } catch (error) {
   var drafterjs = require('drafter.js');
@@ -11,5 +14,8 @@ try {
   module.exports = {
     parse: drafterjs.parse,
     parseSync: drafterjs.parseSync,
+
+    validate: drafterjs.validate,
+    validateSync: drafterjs.validateSync,
   };
 }

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "test": "mocha"
   },
   "dependencies": {
-    "drafter.js": "^2.5.0"
+    "drafter.js": "^2.6.0"
   },
   "optionalDependencies": {
-    "protagonist": "^1.5.0"
+    "protagonist": "^1.6.0"
   },
   "devDependencies": {
     "mocha": "~1.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drafter",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Node API Blueprint Parser",
   "main": "lib/drafter.js",
   "engines": {

--- a/test/validate-test.js
+++ b/test/validate-test.js
@@ -1,0 +1,101 @@
+var expect = require('chai').expect;
+var drafter = require('../lib/drafter.js');
+
+describe('Validating an API Blueprint', function() {
+  context('with a valid API Blueprint', function() {
+    var blueprint = '# API Blueprint\n';
+
+    it('should validate asynchronously', function(done) {
+      drafter.validate(blueprint, {}, function(error, result) {
+        expect(error).to.be.null;
+        expect(result).to.be.null;
+        done();
+      });
+    });
+
+    it('should validate an API Blueprint synchronously', function() {
+      var result = drafter.validateSync(blueprint, {});
+      expect(result).to.be.null;
+    });
+  });
+
+  context('with an API Blueprint that has a warning', function() {
+    var blueprint = '# GET /\n';
+    var parseResult = {
+      element: 'parseResult',
+      content: [
+        {
+          element: 'annotation',
+          meta: {
+            classes: ['warning'],
+          },
+          attributes: {
+            code: 6,
+            sourceMap: [
+              {
+                element: 'sourceMap',
+                content: [
+                  [ 0, 8 ]
+                ]
+              }
+            ]
+          },
+          content: "action is missing a response",
+        }
+      ]
+    }
+
+    it('should validate asynchronously', function(done) {
+      drafter.validate(blueprint, {}, function(error, result) {
+        expect(error).to.be.null;
+        expect(result).to.deep.equal(parseResult);
+        done();
+      });
+    });
+
+    it('should validate an API Blueprint synchronously', function() {
+      var result = drafter.validateSync(blueprint, {});
+      expect(result).to.deep.equal(parseResult);
+    });
+  });
+
+  context('with an API Blueprint that has an error', function() {
+    var blueprint = '# Data Structures\n## A (A)\n';
+    var parseResult = {
+      element: 'parseResult',
+      content: [
+        {
+          element: 'annotation',
+          meta: {
+            classes: ['error'],
+          },
+          attributes: {
+            code: 4,
+            sourceMap: [
+              {
+                element: 'sourceMap',
+                content: [
+                  [ 18, 9 ]
+                ]
+              }
+            ]
+          },
+          content: "base type 'A' circularly referencing itself",
+        }
+      ]
+    }
+
+    it('should validate asynchronously', function(done) {
+      drafter.validate(blueprint, {}, function(error, result) {
+        expect(error).to.be.null;
+        expect(result).to.deep.equal(parseResult);
+        done();
+      });
+    });
+
+    it('should validate an API Blueprint synchronously', function() {
+      var result = drafter.validateSync(blueprint, {});
+      expect(result).to.deep.equal(parseResult);
+    });
+  });
+});


### PR DESCRIPTION
This pull request adds a new validation API which allows you to validate an API Blueprint without serialising the complete API Blueprint.

Tasks:
- [x] Test case with error

Dependencies:
- [x] https://github.com/apiaryio/protagonist/pull/170
- [x] drafter.js
