### PR TITLE
fix(dependencies): use peerDependencies for protagonist

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "drafter.js": "^2.6.0"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "protagonist": "^1.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This will skip protagonist installation when not required - https://docs.npmjs.com/files/package.json#peerdependencies